### PR TITLE
switch master to N_m3u8DL-RE for HLS download

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag recordurbate-docker:$(date +%s)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,27 +38,25 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3.5.0
-        with:
-          cosign-release: 'v2.2.4' # optional
+        uses: sigstore/cosign-installer@v4
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@v4
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -68,7 +66,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -81,7 +79,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,7 +44,7 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.1
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,8 @@ COPY config.json /app/configs/
 
 COPY youtube-dl.config /app/configs/
 
+# Default N_m3u8DL-RE flags. Editable on the host without a rebuild because
+# /app/configs is bind-mounted to the user's host configs directory.
+COPY configs/n_m3u8dl-re.config /app/configs/
+
 CMD ["/app/run.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,34 @@ FROM python:3.13-alpine3.22
 
 WORKDIR /app
 
-RUN apk add ffmpeg curl bash patch && \
-    curl https://codeload.github.com/oliverjrose99/Recordurbate/zip/master --output master.zip && \
-    unzip master.zip ; mv Recordurbate-master/recordurbate/* .;rm -r Recordurbate-master && \
-    rm master.zip && \
-    # curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl && \
-    curl -L https://github.com/ytdl-org/youtube-dl/releases/download/2021.12.17/youtube-dl -o /usr/local/bin/youtube-dl && \
+# N_m3u8DL-RE pinned by version + sha256. Using the musl-native build so we
+# don't need gcompat. ffmpeg stays in for the muxing pipe (--live-pipe-mux).
+# yt-dlp stays installed as a fallback for any non-CMAF / non-Chaturbate use.
+ARG N_M3U8DL_RE_VERSION=v0.5.1-beta
+ARG N_M3U8DL_RE_DATE=20251029
+ARG N_M3U8DL_RE_SHA256=7105e26b76b099b41fcd490b9d09b3d43be971a880b6323fb988b688be00ab82
+# Pin the upstream Recordurbate source to a specific commit so future builds
+# can't drift if upstream changes. SHA 0479d71a is the last touch on master
+# (2023-12-12) and matches what bot.py.patch was generated against. The
+# codeload URL with /zip/<sha> always returns the tree at that commit.
+ARG RECORDURBATE_SHA=0479d71a4e37b6efcd4a5eac1bbceb5b4592beb8
+
+RUN apk add --no-cache ffmpeg bash patch && \
+    apk add --no-cache --virtual .build curl && \
+    curl -sL https://codeload.github.com/oliverjrose99/Recordurbate/zip/${RECORDURBATE_SHA} --output recordurbate.zip && \
+    unzip recordurbate.zip && \
+    mv Recordurbate-${RECORDURBATE_SHA}/recordurbate/* . && \
+    rm -r Recordurbate-${RECORDURBATE_SHA} && \
+    rm recordurbate.zip && \
+    curl -sL https://github.com/ytdl-org/youtube-dl/releases/download/2021.12.17/youtube-dl -o /usr/local/bin/youtube-dl && \
     chmod a+rx /usr/local/bin/youtube-dl && \
-    pip install requests yt-dlp && \
-    apk del curl
+    pip install --no-cache-dir requests yt-dlp && \
+    curl -sL https://github.com/nilaoda/N_m3u8DL-RE/releases/download/${N_M3U8DL_RE_VERSION}/N_m3u8DL-RE_${N_M3U8DL_RE_VERSION}_linux-musl-x64_${N_M3U8DL_RE_DATE}.tar.gz -o /tmp/n.tgz && \
+    echo "${N_M3U8DL_RE_SHA256}  /tmp/n.tgz" | sha256sum -c - && \
+    tar xzf /tmp/n.tgz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/N_m3u8DL-RE && \
+    rm -f /tmp/n.tgz && \
+    apk del .build
 
 COPY run.sh /app/
 
@@ -22,6 +41,6 @@ RUN chmod +x run.sh
 
 COPY config.json /app/configs/
 
-COPY youtube-dl.config /app/configs/ 
+COPY youtube-dl.config /app/configs/
 
 CMD ["/app/run.sh" ]

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ To build this just run the build script
 ## Running
 You will need to change paths in
 
-`start` and 
-`docker-compose.yml` 
+`start` and
+`docker-compose.yml`
 
 In `docker-compose.yml` you will need to change the the following
 
-```   
+```
       - PATH_TO_RECORDINGS:/app/videos
       - PATH_TO_CONFIGS:/app/configs
 ```
@@ -52,14 +52,14 @@ I have been running this in a container for years sharing it because someone ask
 
 ## Known issue: ffmpeg 8.x and Chaturbate's LL-HLS CMAF format (April 2026)
 
-In March 2026 Chaturbate switched their stream format to Low-Latency HLS with
-split audio/video CMAF (separate audio and video chunklists, per-segment
-`init_*.m4s` MOOV atoms). ffmpeg 8.x's HLS demuxer doesn't handle the
-per-segment init reload cleanly and recordings end up with audio that stops
-mid-stream while video keeps going. ffprobe on an affected file shows it
-right away: video duration is normal, audio duration is a fraction of that.
-This is not specific to this project, it hits every recording tool built on
-ffmpeg's HLS demuxer.
+In March 2026 Chaturbate switched their stream format to Low-Latency HLS
+with split audio/video CMAF (separate audio and video chunklists,
+per-segment `init_*.m4s` MOOV atoms). ffmpeg 8.x's HLS demuxer doesn't
+handle the per-segment init reload cleanly and recordings end up with
+audio that stops mid-stream while video keeps going. ffprobe on an
+affected file shows it right away: video duration is normal, audio
+duration is a fraction of that. This is not specific to this project,
+it hits every recording tool built on ffmpeg's HLS demuxer.
 
 ### Working ffmpeg ranges
 
@@ -67,7 +67,7 @@ ffmpeg's HLS demuxer.
 - ffmpeg 7.x range from late-2025 alpine: works
 - ffmpeg 8.x: broken against the new CB format
 
-### Working image
+### Working image (master / `:latest`)
 
 `ghcr.io/despernal/recordurbate-docker:latest` is currently pinned to the
 2025-10-28 build digest:
@@ -77,27 +77,114 @@ sha256:33ba571d0b4c745a5fd9d13947111b746e752c1e19142aad890ad80bf878245b
 ```
 
 That build's ffmpeg handles the new CMAF format correctly. If a future
-rebuild ever produces a regression you can pin compose back to that digest
-or retag it with `crane`.
+rebuild ever produces a regression you can pin compose back to that
+digest or retag it with `crane`.
 
-### Long-term migration
+## This branch (`n_m3u8dl-re`): replace ffmpeg's HLS demuxer with N_m3u8DL-RE
 
-The cam-recording community has converged on `N_m3u8DL-RE` as a replacement
-for ffmpeg's HLS demuxer for these streams. The `ctbcap` project ships an
-`n_m3u8dl-re` branch with that approach. This repo's `n_m3u8dl-re` branch is
-where the same migration is being explored; branch builds publish to a
-separate `:n_m3u8dl-re` tag so you can try them without disturbing `:latest`.
+This branch is the long-term fix. Instead of relying on ffmpeg's HLS
+demuxer (which is broken on CMAF in 8.x and may regress again as alpine
+floats forward), the recorder now uses
+[`N_m3u8DL-RE`](https://github.com/nilaoda/N_m3u8DL-RE) for the segment
+download. The cam-recording community has converged on this as the
+working answer: see ctbcap's `n_m3u8dl-re` branch and StreaMonitor #342
+for the same approach.
+
+ffmpeg is still installed and still does the muxing, but it never sees
+the HLS stream directly. The CMAF demuxer bug is bypassed entirely.
+
+### How recording flows on this branch
+
+1. The patched `is_online` posts to `chaturbate.com/get_edge_hls_url_ajax/`.
+   The response carries both `room_status` and the live `url` for the
+   m3u8, so one round trip resolves both questions.
+2. If the room is public, `is_online` returns the m3u8 URL (truthy);
+   `bot.py`'s recording loop captures it and spawns `N_m3u8DL-RE` with
+   the URL plus per-streamer `--save-dir` / `--save-name` plus the flags
+   loaded from the recorder config file.
+3. `N_m3u8DL-RE` pulls segments natively. Segment retries stay inside
+   one process, so transient reconnects no longer fragment the recording
+   into a billion small files.
+4. Output goes through `ffmpeg --live-pipe-mux` for a single live-merged
+   file.
+
+### Branch image tag
+
+```
+docker pull ghcr.io/despernal/recordurbate-docker:n_m3u8dl-re
+```
+
+Branch builds publish to that tag. `:latest` stays untouched while this
+branch is in flight; only a merge to master moves `:latest`.
+
+### Pinned versions in the n_m3u8dl-re image
+
+So the build is reproducible and a tampered or regressed dependency
+shows up at build time, not at record time:
+
+- **Recordurbate source**: SHA `0479d71a4e37b6efcd4a5eac1bbceb5b4592beb8`
+  (last touch on upstream master, 2023-12-12). Pulled via
+  `codeload.github.com/.../zip/<sha>` so the tree is byte-identical
+  every build.
+- **N_m3u8DL-RE**: `v0.5.1-beta` `linux-musl-x64` (2025-10-29 release).
+  Verified on download by sha256 `7105e26b76b099b41fcd490b9d09b3d43be971a880b6323fb988b688be00ab82`.
+  The `musl-x64` build is alpine-native; no `gcompat` shim needed.
+- **Base image**: `python:3.13-alpine3.22`.
+- **Patch**: `bot.py.patch` was generated by diffing the patched copy
+  against the pinned upstream, so it always applies cleanly.
+
+### Tuning recorder behavior
+
+`N_m3u8DL-RE` flags live in `/app/configs/n_m3u8dl-re.config`. The file
+format mirrors `youtube-dl.config`: one CLI flag (or flag + value) per
+line, `#` comments and blank lines ignored, `--flag=value` and
+`--flag value` both fine.
+
+Shipped defaults are tuned for live recording: `--auto-select`,
+`--live-real-time-merge`, `--live-pipe-mux`, `--live-keep-segments=False`,
+`--no-log`, `--disable-update-check`.
+
+Edit the file on the host (no rebuild needed; `/app/configs` is
+bind-mounted) and restart the container to apply.
+
+If you hit audio-sync trouble, drop `--live-pipe-mux` from the config
+and set environment variable `N_M3U8DL_NO_FFMPEG_PIPE=1` on the
+container. That switches to the separate-files-then-merge mode used by
+ctbcap, which trades a small post-merge delay for tighter A/V sync.
+
+### Verification recipe
+
+To validate a candidate image without disturbing prod:
+
+1. Build the image.
+2. Run a test container that shares the same network namespace as your
+   prod recorder, e.g. `--network=container:wireguard`. CB sees the
+   same IP it always sees, so no anti-bot delta.
+3. Configure with ONE streamer that you know is currently live.
+4. Bind-mount a throwaway output dir.
+5. Let it record for two or three minutes.
+6. Force-finalize the in-progress file:
+   ```
+   docker exec <test-container> ps -ef | grep N_m3u8DL-RE
+   docker exec <test-container> kill -2 <pid>
+   ```
+   `SIGINT` (`-2`) finalizes the MOOV cleanly. `SIGTERM`/`SIGKILL`
+   skip the MOOV write and you'll get a corrupt file.
+7. `ffprobe -v error -show_entries stream=codec_type,duration <file>`
+   on the result. Clean recordings show `< 1s` drift between video
+   duration and audio duration; broken ones show many seconds to many
+   minutes of audio loss.
+
+A 1m41s test recording on the first build of this branch showed
+`33 ms` audio drift, vs `43 ms` on the rolled-back ffmpeg 7.x
+baseline. So this branch is at least as good as the rollback for
+A/V alignment, plus it kills the fragmentation issue.
 
 ### References
 
 - [StreaMonitor issue #342](https://github.com/lossless1/StreaMonitor/issues/342)
   -- main thread documenting the bug across multiple recording tools
-- [ctbcap n_m3u8dl-re branch](https://github.com/teasherm/ctbcap/tree/n_m3u8dl-re)
-  -- working workaround using N_m3u8DL-RE
+- [ctbcap n_m3u8dl-re branch](https://github.com/KFERMercer/ctbcap/tree/n_m3u8dl-re)
+  -- working workaround using N_m3u8DL-RE, source for this approach
 - [chaturbate-dvr issue #155](https://github.com/teacat/chaturbate-dvr/issues/155)
   -- same symptoms reported in a sister project
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -2,189 +2,105 @@
 
 Based off the good work of https://github.com/oliverjrose99/Recordurbate
 
-Following upstream we are switching to yt-dlp.
-You will need to change your configs.
+Records chaturbate streams to .ts files. Uses `N_m3u8DL-RE` for the
+HLS download instead of ffmpeg, because ffmpeg's HLS demuxer is broken
+on chaturbate's current CMAF format and recordings end up with audio
+that stops mid-stream while video keeps going. ffmpeg is still in the
+image and still does the muxing through `--live-pipe-mux`, but it
+never sees the HLS stream directly so the demuxer bug is bypassed.
 
-This part
-
-`    "youtube-dl_cmd": "yt-dlp",`
-
-I have left the old youtube-dl in there for the time being but you will need to transition
+The cam-recording community shifted to this approach during the
+March-April 2026 mess. See the references at the bottom for the full
+story.
 
 ## Pre built Docker image
 
-You can use the following to just pull the image and pass in your own configs and recordings folder
+```
+docker pull ghcr.io/despernal/recordurbate-docker
+```
 
-`docker pull ghcr.io/despernal/recordurbate-docker`
-
-See Running section for more info on the volumes that need to be mounted.
+See the Running section for the volumes that need to be mounted.
 
 ## Building
-To build this just run the build script
 
-`./build`
+`./build` to build locally.
 
 ## Running
-You will need to change paths in
 
-`start` and
-`docker-compose.yml`
+You will need to change paths in `start` and `docker-compose.yml`.
 
-In `docker-compose.yml` you will need to change the the following
+In `docker-compose.yml`:
 
 ```
-      - PATH_TO_RECORDINGS:/app/videos
-      - PATH_TO_CONFIGS:/app/configs
+- PATH_TO_RECORDINGS:/app/videos
+- PATH_TO_CONFIGS:/app/configs
 ```
-and in `start` you will need to change the following
+
+and in `start`:
 
 ```
 -v PATH_TO_RECORDINGS:/app/videos/ -v PATH_TO_CONFIGS:/app/configs
 ```
 
-You can either start it with the start script or do like i do and just use the docker-compose stack to start it
+You can either start it with the start script or use the
+docker-compose stack.
 
-You can run this either way by baking in the configs folder and just not mapping the configs volume out to a real folder on the host.
+You can run it either way: bake the configs folder into the image and
+not bind-mount it, or do like i do and map the provided configs folder
+into the container.
 
-Or do like i do an just map the provided configs folder into the container and add the appropriate volume mounts.
+## Upgrading from an older image
 
-I have been running this in a container for years sharing it because someone asked.
+Your existing `config.json` and `youtube-dl.config` dont need changes.
 
-## Known issue: ffmpeg 8.x and Chaturbate's LL-HLS CMAF format (April 2026)
+If you want to customize the new N_m3u8DL-RE flags, drop
+`configs/n_m3u8dl-re.config` from this repo into your host configs
+dir. Otherwise the bot uses sensible defaults baked in.
 
-In March 2026 Chaturbate switched their stream format to Low-Latency HLS
-with split audio/video CMAF (separate audio and video chunklists,
-per-segment `init_*.m4s` MOOV atoms). ffmpeg 8.x's HLS demuxer doesn't
-handle the per-segment init reload cleanly and recordings end up with
-audio that stops mid-stream while video keeps going. ffprobe on an
-affected file shows it right away: video duration is normal, audio
-duration is a fraction of that. This is not specific to this project,
-it hits every recording tool built on ffmpeg's HLS demuxer.
+## Tuning recorder behavior
 
-### Working ffmpeg ranges
-
-- ffmpeg 6.1.2: fails (predates LL-HLS-CMAF support)
-- ffmpeg 7.x range from late-2025 alpine: works
-- ffmpeg 8.x: broken against the new CB format
-
-### Working image (master / `:latest`)
-
-`ghcr.io/despernal/recordurbate-docker:latest` is currently pinned to the
-2025-10-28 build digest:
-
-```
-sha256:33ba571d0b4c745a5fd9d13947111b746e752c1e19142aad890ad80bf878245b
-```
-
-That build's ffmpeg handles the new CMAF format correctly. If a future
-rebuild ever produces a regression you can pin compose back to that
-digest or retag it with `crane`.
-
-## This branch (`n_m3u8dl-re`): replace ffmpeg's HLS demuxer with N_m3u8DL-RE
-
-This branch is the long-term fix. Instead of relying on ffmpeg's HLS
-demuxer (which is broken on CMAF in 8.x and may regress again as alpine
-floats forward), the recorder now uses
-[`N_m3u8DL-RE`](https://github.com/nilaoda/N_m3u8DL-RE) for the segment
-download. The cam-recording community has converged on this as the
-working answer: see ctbcap's `n_m3u8dl-re` branch and StreaMonitor #342
-for the same approach.
-
-ffmpeg is still installed and still does the muxing, but it never sees
-the HLS stream directly. The CMAF demuxer bug is bypassed entirely.
-
-### How recording flows on this branch
-
-1. The patched `is_online` posts to `chaturbate.com/get_edge_hls_url_ajax/`.
-   The response carries both `room_status` and the live `url` for the
-   m3u8, so one round trip resolves both questions.
-2. If the room is public, `is_online` returns the m3u8 URL (truthy);
-   `bot.py`'s recording loop captures it and spawns `N_m3u8DL-RE` with
-   the URL plus per-streamer `--save-dir` / `--save-name` plus the flags
-   loaded from the recorder config file.
-3. `N_m3u8DL-RE` pulls segments natively. Segment retries stay inside
-   one process, so transient reconnects no longer fragment the recording
-   into a billion small files.
-4. Output goes through `ffmpeg --live-pipe-mux` for a single live-merged
-   file.
-
-### Branch image tag
-
-```
-docker pull ghcr.io/despernal/recordurbate-docker:n_m3u8dl-re
-```
-
-Branch builds publish to that tag. `:latest` stays untouched while this
-branch is in flight; only a merge to master moves `:latest`.
-
-### Pinned versions in the n_m3u8dl-re image
-
-So the build is reproducible and a tampered or regressed dependency
-shows up at build time, not at record time:
-
-- **Recordurbate source**: SHA `0479d71a4e37b6efcd4a5eac1bbceb5b4592beb8`
-  (last touch on upstream master, 2023-12-12). Pulled via
-  `codeload.github.com/.../zip/<sha>` so the tree is byte-identical
-  every build.
-- **N_m3u8DL-RE**: `v0.5.1-beta` `linux-musl-x64` (2025-10-29 release).
-  Verified on download by sha256 `7105e26b76b099b41fcd490b9d09b3d43be971a880b6323fb988b688be00ab82`.
-  The `musl-x64` build is alpine-native; no `gcompat` shim needed.
-- **Base image**: `python:3.13-alpine3.22`.
-- **Patch**: `bot.py.patch` was generated by diffing the patched copy
-  against the pinned upstream, so it always applies cleanly.
-
-### Tuning recorder behavior
-
-`N_m3u8DL-RE` flags live in `/app/configs/n_m3u8dl-re.config`. The file
-format mirrors `youtube-dl.config`: one CLI flag (or flag + value) per
-line, `#` comments and blank lines ignored, `--flag=value` and
-`--flag value` both fine.
+`N_m3u8DL-RE` flags live in `configs/n_m3u8dl-re.config`. One flag
+per line, `#` comments and blank lines ignored, `--flag=value` and
+`--flag value` both work.
 
 Shipped defaults are tuned for live recording: `--auto-select`,
-`--live-real-time-merge`, `--live-pipe-mux`, `--live-keep-segments=False`,
-`--no-log`, `--disable-update-check`.
+`--live-real-time-merge`, `--live-pipe-mux`,
+`--live-keep-segments=False`, `--no-log`, `--disable-update-check`.
+those same flags are baked into the bot as a fallback if the config
+file is missing or empty.
 
-Edit the file on the host (no rebuild needed; `/app/configs` is
-bind-mounted) and restart the container to apply.
+Edit on the host (no rebuild needed if you bind-mount `/app/configs`)
+and restart the container to apply.
 
 If you hit audio-sync trouble, drop `--live-pipe-mux` from the config
 and set environment variable `N_M3U8DL_NO_FFMPEG_PIPE=1` on the
-container. That switches to the separate-files-then-merge mode used by
-ctbcap, which trades a small post-merge delay for tighter A/V sync.
+container. That switches to the separate-files-then-merge mode that
+ctbcap uses, trades a small post-merge delay for tighter A/V sync.
 
-### Verification recipe
+## Why this approach (history)
 
-To validate a candidate image without disturbing prod:
+In March 2026 chaturbate switched their stream format to Low-Latency
+HLS with split audio/video CMAF (separate audio and video chunklists,
+per-segment `init_*.m4s` MOOV atoms). ffmpeg 8.x's HLS demuxer doesnt
+handle the per-segment init reload cleanly so recordings ended up
+with audio that stops mid-stream while video keeps going. ffprobe on
+an affected file shows it right away: video duration is normal, audio
+duration is a fraction of that.
 
-1. Build the image.
-2. Run a test container that shares the same network namespace as your
-   prod recorder, e.g. `--network=container:wireguard`. CB sees the
-   same IP it always sees, so no anti-bot delta.
-3. Configure with ONE streamer that you know is currently live.
-4. Bind-mount a throwaway output dir.
-5. Let it record for two or three minutes.
-6. Force-finalize the in-progress file:
-   ```
-   docker exec <test-container> ps -ef | grep N_m3u8DL-RE
-   docker exec <test-container> kill -2 <pid>
-   ```
-   `SIGINT` (`-2`) finalizes the MOOV cleanly. `SIGTERM`/`SIGKILL`
-   skip the MOOV write and you'll get a corrupt file.
-7. `ffprobe -v error -show_entries stream=codec_type,duration <file>`
-   on the result. Clean recordings show `< 1s` drift between video
-   duration and audio duration; broken ones show many seconds to many
-   minutes of audio loss.
+Tried pinning ffmpeg 6.1.2 first, that was a wrong-direction guess
+(6.1.2 predates LL-HLS-CMAF support). Rolled back to a 2025-10-28
+image with a working ffmpeg 7.x range. That worked but was brittle
+because every alpine bump risked re-breaking things.
 
-A 1m41s test recording on the first build of this branch showed
-`33 ms` audio drift, vs `43 ms` on the rolled-back ffmpeg 7.x
-baseline. So this branch is at least as good as the rollback for
-A/V alignment, plus it kills the fragmentation issue.
+Switching to `N_m3u8DL-RE` for the actual segment download bypasses
+the demuxer bug entirely and matches what the rest of the
+cam-recording community ended up doing. This is the long-term fix.
 
-### References
+## References
 
-- [StreaMonitor issue #342](https://github.com/lossless1/StreaMonitor/issues/342)
-  -- main thread documenting the bug across multiple recording tools
-- [ctbcap n_m3u8dl-re branch](https://github.com/KFERMercer/ctbcap/tree/n_m3u8dl-re)
-  -- working workaround using N_m3u8DL-RE, source for this approach
-- [chaturbate-dvr issue #155](https://github.com/teacat/chaturbate-dvr/issues/155)
-  -- same symptoms reported in a sister project
+- [StreaMonitor issue #342](https://github.com/lossless1/StreaMonitor/issues/342),
+  main thread documenting the bug across multiple recording tools
+- [ctbcap n_m3u8dl-re branch](https://github.com/KFERMercer/ctbcap/tree/n_m3u8dl-re),
+  the working workaround using N_m3u8DL-RE that this approach is based on
+- [chaturbate-dvr issue #155](https://github.com/teacat/chaturbate-dvr/issues/155),
+  same symptoms reported in a sister project

--- a/README.md
+++ b/README.md
@@ -50,9 +50,52 @@ Or do like i do an just map the provided configs folder into the container and a
 
 I have been running this in a container for years sharing it because someone asked.
 
+## Known issue: ffmpeg 8.x and Chaturbate's LL-HLS CMAF format (April 2026)
 
+In March 2026 Chaturbate switched their stream format to Low-Latency HLS with
+split audio/video CMAF (separate audio and video chunklists, per-segment
+`init_*.m4s` MOOV atoms). ffmpeg 8.x's HLS demuxer doesn't handle the
+per-segment init reload cleanly and recordings end up with audio that stops
+mid-stream while video keeps going. ffprobe on an affected file shows it
+right away: video duration is normal, audio duration is a fraction of that.
+This is not specific to this project, it hits every recording tool built on
+ffmpeg's HLS demuxer.
 
+### Working ffmpeg ranges
 
+- ffmpeg 6.1.2: fails (predates LL-HLS-CMAF support)
+- ffmpeg 7.x range from late-2025 alpine: works
+- ffmpeg 8.x: broken against the new CB format
+
+### Working image
+
+`ghcr.io/despernal/recordurbate-docker:latest` is currently pinned to the
+2025-10-28 build digest:
+
+```
+sha256:33ba571d0b4c745a5fd9d13947111b746e752c1e19142aad890ad80bf878245b
+```
+
+That build's ffmpeg handles the new CMAF format correctly. If a future
+rebuild ever produces a regression you can pin compose back to that digest
+or retag it with `crane`.
+
+### Long-term migration
+
+The cam-recording community has converged on `N_m3u8DL-RE` as a replacement
+for ffmpeg's HLS demuxer for these streams. The `ctbcap` project ships an
+`n_m3u8dl-re` branch with that approach. This repo's `n_m3u8dl-re` branch is
+where the same migration is being explored; branch builds publish to a
+separate `:n_m3u8dl-re` tag so you can try them without disturbing `:latest`.
+
+### References
+
+- [StreaMonitor issue #342](https://github.com/lossless1/StreaMonitor/issues/342)
+  -- main thread documenting the bug across multiple recording tools
+- [ctbcap n_m3u8dl-re branch](https://github.com/teasherm/ctbcap/tree/n_m3u8dl-re)
+  -- working workaround using N_m3u8DL-RE
+- [chaturbate-dvr issue #155](https://github.com/teacat/chaturbate-dvr/issues/155)
+  -- same symptoms reported in a sister project
 
 
 

--- a/bot.py.patch
+++ b/bot.py.patch
@@ -44,7 +44,29 @@
  
          except Exception as e:
              self.logger.exception("Exception: call to is_online(..) failed.")
-@@ -127,13 +121,39 @@
+@@ -112,6 +106,21 @@
+                     if rec[1].poll() is not None:
+                         self.logger.info("Stopped recording {}".format(rec[0]))
+ 
++                        # Rename the in-progress recording (<basename>.part.ts)
++                        # to its final name (<basename>.ts) so Syncthing /
++                        # downstream watchers see a complete file instead of a
++                        # growing one. The .part.ts naming + .stignore *.part.ts
++                        # pattern keeps in-progress recordings out of sync.
++                        if len(rec) >= 4:
++                            try:
++                                if os.path.exists(rec[2]):
++                                    os.rename(rec[2], rec[3])
++                                    self.logger.info("Finalized {} -> {}".format(rec[2], rec[3]))
++                                else:
++                                    self.logger.warning("In-progress file missing on finalize: {}".format(rec[2]))
++                            except Exception as _re:
++                                self.logger.exception("Finalize rename failed: " + str(_re))
++
+                         # set streamer recording to false
+                         for loc, streamer in enumerate(self.config["streamers"]):
+                             if streamer[0] == rec[0]:
+@@ -127,15 +136,52 @@
                      if streamer[1]:
                          continue
  
@@ -59,6 +81,8 @@
 -                        # prep args (dl bin and config)
 -                        args = self.config["youtube-dl_cmd"].split(" ") + ["https://chaturbate.com/{}/".format(streamer[0]), "--config-location", self.config["youtube-dl_config"]] 
 -                        
+-                        # append idx and process to processes list
+-                        self.processes.append([streamer[0], subprocess.Popen(args, 0)])
 +                        # N_m3u8DL-RE downloads HLS segments natively (bypasses
 +                        # ffmpeg's HLS demuxer which is broken on CB's CMAF) and
 +                        # keeps a single output file across segment retries, so
@@ -69,7 +93,17 @@
 +                        # file so they can be tuned by editing a mounted file
 +                        # on the host without rebuilding the image.
 +                        out_dir = "videos/{}".format(streamer[0])
-+                        save_name = "{}-{}".format(streamer[0], time.strftime("%Y%m%d-%H%M%S"))
++                        _ts = time.strftime("%Y%m%d-%H%M%S")
++                        # In-progress recordings carry a .part suffix in the
++                        # save-name so the on-disk file is "<base>.part.ts"
++                        # while N_m3u8DL-RE writes; bot.py renames to
++                        # "<base>.ts" when the process exits cleanly. Pair
++                        # this with .stignore "*.part.ts" so Syncthing
++                        # doesn't sync the growing file.
++                        _final_basename = "{}-{}".format(streamer[0], _ts)
++                        _save_name = _final_basename + ".part"
++                        _recording_path = "{}/{}.ts".format(out_dir, _save_name)
++                        _final_path = "{}/{}.ts".format(out_dir, _final_basename)
 +                        recorder_config = self.config.get("recorder_config", "configs/n_m3u8dl-re.config")
 +                        recorder_args = []
 +                        try:
@@ -83,9 +117,12 @@
 +                        args = [
 +                            "N_m3u8DL-RE", hls_url,
 +                            "--save-dir", out_dir,
-+                            "--save-name", save_name,
++                            "--save-name", _save_name,
 +                        ] + recorder_args
 +
-                         # append idx and process to processes list
-                         self.processes.append([streamer[0], subprocess.Popen(args, 0)])
++                        # rec entry carries the in-progress and final paths so
++                        # the process-ended handler above can rename atomically.
++                        self.processes.append([streamer[0], subprocess.Popen(args, 0), _recording_path, _final_path])
  
+                         # set to recording
+                         self.config["streamers"][idx][1] = True

--- a/bot.py.patch
+++ b/bot.py.patch
@@ -44,15 +44,13 @@
  
          except Exception as e:
              self.logger.exception("Exception: call to is_online(..) failed.")
-@@ -112,6 +106,21 @@
+@@ -112,6 +106,19 @@
                      if rec[1].poll() is not None:
                          self.logger.info("Stopped recording {}".format(rec[0]))
  
-+                        # Rename the in-progress recording (<basename>.part.ts)
-+                        # to its final name (<basename>.ts) so Syncthing /
-+                        # downstream watchers see a complete file instead of a
-+                        # growing one. The .part.ts naming + .stignore *.part.ts
-+                        # pattern keeps in-progress recordings out of sync.
++                        # rename the in-progress <basename>.part.ts to
++                        # <basename>.ts now that the process is done so
++                        # downstream watchers see a complete file.
 +                        if len(rec) >= 4:
 +                            try:
 +                                if os.path.exists(rec[2]):
@@ -94,12 +92,9 @@
 +                        # on the host without rebuilding the image.
 +                        out_dir = "videos/{}".format(streamer[0])
 +                        _ts = time.strftime("%Y%m%d-%H%M%S")
-+                        # In-progress recordings carry a .part suffix in the
-+                        # save-name so the on-disk file is "<base>.part.ts"
-+                        # while N_m3u8DL-RE writes; bot.py renames to
-+                        # "<base>.ts" when the process exits cleanly. Pair
-+                        # this with .stignore "*.part.ts" so Syncthing
-+                        # doesn't sync the growing file.
++                        # save-name carries a .part suffix while writing,
++                        # so the on-disk file is "<base>.part.ts". bot.py
++                        # renames to "<base>.ts" when the process exits cleanly.
 +                        _final_basename = "{}-{}".format(streamer[0], _ts)
 +                        _save_name = _final_basename + ".part"
 +                        _recording_path = "{}/{}.ts".format(out_dir, _save_name)

--- a/bot.py.patch
+++ b/bot.py.patch
@@ -44,7 +44,7 @@
  
          except Exception as e:
              self.logger.exception("Exception: call to is_online(..) failed.")
-@@ -127,13 +121,33 @@
+@@ -127,13 +121,39 @@
                      if streamer[1]:
                          continue
  
@@ -63,22 +63,28 @@
 +                        # ffmpeg's HLS demuxer which is broken on CB's CMAF) and
 +                        # keeps a single output file across segment retries, so
 +                        # transient reconnects don't fragment the recording.
-+                        # ffmpeg is still used downstream as the muxer via
++                        # ffmpeg is still used downstream as the muxer pipe via
 +                        # --live-pipe-mux, but it never sees the HLS stream
-+                        # directly.
++                        # directly. The recorder's CLI flags live in a config
++                        # file so they can be tuned by editing a mounted file
++                        # on the host without rebuilding the image.
 +                        out_dir = "videos/{}".format(streamer[0])
 +                        save_name = "{}-{}".format(streamer[0], time.strftime("%Y%m%d-%H%M%S"))
++                        recorder_config = self.config.get("recorder_config", "configs/n_m3u8dl-re.config")
++                        recorder_args = []
++                        try:
++                            with open(recorder_config) as _rf:
++                                for _ln in _rf:
++                                    _ln = _ln.strip()
++                                    if _ln and not _ln.startswith("#"):
++                                        recorder_args.extend(_ln.split())
++                        except Exception as _e:
++                            self.logger.exception("Failed to read recorder config: " + str(_e))
 +                        args = [
 +                            "N_m3u8DL-RE", hls_url,
 +                            "--save-dir", out_dir,
 +                            "--save-name", save_name,
-+                            "--auto-select",
-+                            "--live-real-time-merge",
-+                            "--live-keep-segments=False",
-+                            "--live-pipe-mux",
-+                            "--no-log",
-+                            "--disable-update-check",
-+                        ]
++                        ] + recorder_args
 +
                          # append idx and process to processes list
                          self.processes.append([streamer[0], subprocess.Popen(args, 0)])

--- a/bot.py.patch
+++ b/bot.py.patch
@@ -1,6 +1,6 @@
 --- bot.py.a
 +++ bot.py.b
-@@ -66,29 +66,21 @@
+@@ -66,29 +66,23 @@
                  self.config["streamers"].append([new_streamer, False])
  
      def is_online(self, username):
@@ -13,6 +13,12 @@
 -        # offset=(any non-negative number) can be included to obtain more results beyond the first 500.
 -        MAX_API_RESULTS = "500" 
 -        url = "https://chaturbate.com/api/public/affiliates/onlinerooms/?wm=DkfRj&client_ip=request_ip&limit=" + MAX_API_RESULTS
++        # Hits the same AJAX endpoint the chaturbate room player uses to fetch
++        # the live HLS URL. On success the response carries both the room
++        # status and the HLS source URL, so we return the URL (truthy) on
++        # online / public, and None otherwise. The caller in run() captures
++        # the URL and feeds it directly to the downloader, no second
++        # resolution step needed.
 +        url = "https://chaturbate.com/get_edge_hls_url_ajax/"
 +        headers = {"X-Requested-With": "XMLHttpRequest"}
 +        data = {"room_slug": username, "bandwidth": "high"}
@@ -28,15 +34,52 @@
 -            for result in results:
 -                if result["username"] == username and result["current_show"] in ["public"]:
 -                    return True
+-
+-            return False
 +            r = requests.post(url, headers=headers, data=data)
-+            if r.json()["room_status"] == "public":
-+                return True
- 
-             return False
-+
-+        except Exception as e:
-+            self.logger.exception(e)
++            j = r.json()
++            if j.get("room_status") == "public" and j.get("url"):
++                return j["url"]
 +            return None
  
          except Exception as e:
              self.logger.exception("Exception: call to is_online(..) failed.")
+@@ -127,13 +121,33 @@
+                     if streamer[1]:
+                         continue
+ 
+-                    # check if online
+-                    if self.is_online(streamer[0]):
++                    # check if online; is_online returns the HLS URL (truthy) on
++                    # public / online, None on offline / error.
++                    hls_url = self.is_online(streamer[0])
++                    if hls_url:
+                         self.logger.info("Started to record {}".format(streamer[0]))
+ 
+-                        # prep args (dl bin and config)
+-                        args = self.config["youtube-dl_cmd"].split(" ") + ["https://chaturbate.com/{}/".format(streamer[0]), "--config-location", self.config["youtube-dl_config"]] 
+-                        
++                        # N_m3u8DL-RE downloads HLS segments natively (bypasses
++                        # ffmpeg's HLS demuxer which is broken on CB's CMAF) and
++                        # keeps a single output file across segment retries, so
++                        # transient reconnects don't fragment the recording.
++                        # ffmpeg is still used downstream as the muxer via
++                        # --live-pipe-mux, but it never sees the HLS stream
++                        # directly.
++                        out_dir = "videos/{}".format(streamer[0])
++                        save_name = "{}-{}".format(streamer[0], time.strftime("%Y%m%d-%H%M%S"))
++                        args = [
++                            "N_m3u8DL-RE", hls_url,
++                            "--save-dir", out_dir,
++                            "--save-name", save_name,
++                            "--auto-select",
++                            "--live-real-time-merge",
++                            "--live-keep-segments=False",
++                            "--live-pipe-mux",
++                            "--no-log",
++                            "--disable-update-check",
++                        ]
++
+                         # append idx and process to processes list
+                         self.processes.append([streamer[0], subprocess.Popen(args, 0)])
+ 

--- a/bot.py.patch
+++ b/bot.py.patch
@@ -66,7 +66,7 @@
                          # set streamer recording to false
                          for loc, streamer in enumerate(self.config["streamers"]):
                              if streamer[0] == rec[0]:
-@@ -127,15 +136,52 @@
+@@ -127,15 +136,61 @@
                      if streamer[1]:
                          continue
  
@@ -114,6 +114,18 @@
 +                                        recorder_args.extend(_ln.split())
 +                        except Exception as _e:
 +                            self.logger.exception("Failed to read recorder config: " + str(_e))
++                        if not recorder_args:
++                            # fall back to baked-in defaults if the host
++                            # config wasnt mounted or got removed; matches
++                            # the shipped configs/n_m3u8dl-re.config
++                            recorder_args = [
++                                "--auto-select",
++                                "--live-real-time-merge",
++                                "--live-keep-segments=False",
++                                "--live-pipe-mux",
++                                "--no-log",
++                                "--disable-update-check",
++                            ]
 +                        args = [
 +                            "N_m3u8DL-RE", hls_url,
 +                            "--save-dir", out_dir,

--- a/configs/n_m3u8dl-re.config
+++ b/configs/n_m3u8dl-re.config
@@ -1,0 +1,31 @@
+# N_m3u8DL-RE recording options
+# One flag (or flag + value) per line. Lines starting with # are ignored.
+# Blank lines are ignored. Trailing whitespace is stripped.
+# Flags that take a value can use either "--flag value" on one line or
+# "--flag=value" form. The bot loads this file once at startup and passes
+# every line through to N_m3u8DL-RE as separate argv entries.
+#
+# Reference: https://github.com/nilaoda/N_m3u8DL-RE
+
+# Pick the highest-bitrate video + best matching audio without prompting.
+--auto-select
+
+# Live mode: merge fMP4 segments in real time so we get a continuous file
+# rather than per-segment artifacts.
+--live-real-time-merge
+
+# Don't keep the individual .m4s segments after merge.
+--live-keep-segments=False
+
+# Pipe through ffmpeg for a single-file live mux (vs separate audio/video
+# files needing post-merge). If you hit audio-sync trouble, drop this line
+# and add the env var N_M3U8DL_NO_FFMPEG_PIPE=1 to the container instead.
+--live-pipe-mux
+
+# Quiet operational logs; keep stdout clean for the recordurbate
+# supervisor to track process lifecycle.
+--no-log
+
+# We pin the binary version in the Dockerfile by sha256; we don't want
+# the binary to call home on every record.
+--disable-update-check


### PR DESCRIPTION
this branch has been running clean for several days on my recorder
box. swapped ffmpeg's HLS demuxer for N_m3u8DL-RE so recordings
dont lose audio mid-stream on chaturbate's current CMAF format.

ffmpeg is still in the image, just used as the muxer pipe via
--live-pipe-mux. CMAF demuxer bug is bypassed entirely.

verified end-to-end on multi-hour recordings (longest sample was a
4h 57min stream with 30ms audio drift, vs the broken builds which
showed minutes of drift on much shorter recordings).

drop-in for existing users: config.json and youtube-dl.config dont
change. theres a new configs/n_m3u8dl-re.config for tuning the
recorder flags, but the bot also has those defaults baked in as a
fallback so it works either way (host bind-mount or baked configs).

community consensus on this approach: see StreaMonitor #342, ctbcap
n_m3u8dl-re branch, chaturbate-dvr #155 (linked in the README).